### PR TITLE
Use Monad instead of MonadError

### DIFF
--- a/modules/core/src/main/scala/orcus/table.scala
+++ b/modules/core/src/main/scala/orcus/table.scala
@@ -1,6 +1,6 @@
 package orcus
 
-import cats.MonadError
+import cats.{Monad, MonadError}
 import cats.data.Kleisli
 import org.apache.hadoop.conf.{Configuration => HConfig}
 import org.apache.hadoop.hbase.client.{
@@ -20,13 +20,13 @@ object table {
 
   def getName[F[_]](t: HTable)(
       implicit
-      ME: MonadError[F, Throwable]
+      ME: Monad[F]
   ): F[HTableName] =
     ME.pure(t.getName)
 
   def getConfiguration[F[_]](t: HTable)(
       implicit
-      ME: MonadError[F, Throwable]
+      ME: Monad[F]
   ): F[HConfig] =
     ME.pure(t.getConfiguration)
 


### PR DESCRIPTION
This PR, that implement to use `Monad` instead of `MonadError` when method not used `MonadError.raiseError`.