### PR TITLE
Remove the timestamp argument from PutEncoder and PutFamilyEncoder

### DIFF
--- a/modules/core/src/test/scala/orcus/codec/PutEncoderSpec.scala
+++ b/modules/core/src/test/scala/orcus/codec/PutEncoderSpec.scala
@@ -17,7 +17,7 @@ class PutEncoderSpec extends FunSpec {
       val row = Bytes.toBytes("row")
       val ts  = Long.MaxValue
       val x   = X(A(1), B("2"), C(3), D(None))
-      val p   = PutEncoder[X].apply(new Put(row), x, ts)
+      val p   = PutEncoder[X].apply(new Put(row), x)
       assert(p.has(Bytes.toBytes("a"), Bytes.toBytes("x"), ts, Bytes.toBytes(1)))
       assert(p.has(Bytes.toBytes("b"), Bytes.toBytes("y"), ts, Bytes.toBytes("2")))
       assert(p.has(Bytes.toBytes("c"), Bytes.toBytes("z"), ts, Bytes.toBytes(3L)))
@@ -27,7 +27,7 @@ class PutEncoderSpec extends FunSpec {
       val row = Bytes.toBytes("row")
       val ts  = Long.MaxValue
       val map = Map("a" -> A(1), "b" -> A(2), "c" -> A(3))
-      val p   = PutEncoder[Map[String, A]].apply(new Put(row), map, ts)
+      val p   = PutEncoder[Map[String, A]].apply(new Put(row), map)
       assert(p.has(Bytes.toBytes("a"), Bytes.toBytes("x"), ts, Bytes.toBytes(1)))
       assert(p.has(Bytes.toBytes("b"), Bytes.toBytes("x"), ts, Bytes.toBytes(2)))
       assert(p.has(Bytes.toBytes("c"), Bytes.toBytes("x"), ts, Bytes.toBytes(3)))

--- a/modules/core/src/test/scala/orcus/codec/PutFamilyEncoderSpec.scala
+++ b/modules/core/src/test/scala/orcus/codec/PutFamilyEncoderSpec.scala
@@ -14,7 +14,7 @@ class PutFamilyEncoderSpec extends FunSpec {
       val cf  = Bytes.toBytes("cf")
       val ts  = 1L
       val a   = A(1, "2", 3.0)
-      val p   = PutFamilyEncoder[A].apply(new Put(row), cf, a, ts)
+      val p   = PutFamilyEncoder[A].apply(new Put(row, ts), cf, a)
       assert(p.has(cf, Bytes.toBytes("a"), ts, Bytes.toBytes(1)))
       assert(p.has(cf, Bytes.toBytes("b"), ts, Bytes.toBytes("2")))
       assert(p.has(cf, Bytes.toBytes("c"), ts, Bytes.toBytes(3.0)))
@@ -24,7 +24,7 @@ class PutFamilyEncoderSpec extends FunSpec {
       val cf  = Bytes.toBytes("cf")
       val ts  = 1L
       val map = Map("a" -> 1, "b" -> 2, "c" -> 3)
-      val p   = PutFamilyEncoder[Map[String, Int]].apply(new Put(row), cf, map, ts)
+      val p   = PutFamilyEncoder[Map[String, Int]].apply(new Put(row, ts), cf, map)
       assert(p.has(cf, Bytes.toBytes("a"), ts, Bytes.toBytes(1)))
       assert(p.has(cf, Bytes.toBytes("b"), ts, Bytes.toBytes(2)))
       assert(p.has(cf, Bytes.toBytes("c"), ts, Bytes.toBytes(3)))

--- a/modules/example/src/main/scala/example/bigtable/FreeMain.scala
+++ b/modules/example/src/main/scala/example/bigtable/FreeMain.scala
@@ -38,7 +38,7 @@ object FreeMain extends App {
         _ <- HPut.withDurability(Durability.ASYNC_WAL)
       } yield o
 
-      val x = PutEncoder[Hello].apply(new Put(rowKey, ts), hello, Long.MaxValue)
+      val x = PutEncoder[Hello].apply(new Put(rowKey, ts), hello)
       put.run(x)
     }
 


### PR DESCRIPTION
A timestamp is can be passed to Put's constructor.