### PR TITLE
Add benchmark of self decoding

### DIFF
--- a/modules/benchmark/src/test/scala/orcus/codec/benchmark/DecoderBench.scala
+++ b/modules/benchmark/src/test/scala/orcus/codec/benchmark/DecoderBench.scala
@@ -3,22 +3,54 @@ package orcus.codec.benchmark
 import java.util.concurrent.TimeUnit
 
 import orcus.codec.Decoder
+import org.apache.hadoop.hbase.util.Bytes
 import org.openjdk.jmh.annotations._
+
+import scala.collection.mutable
+import scala.util.control.NonFatal
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @Warmup(iterations = 10, time = 1)
-@Measurement(iterations = 10, time = 2)
+@Measurement(iterations = 10, time = 1)
 @Threads(1)
 @Fork(2)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 class DecoderBench extends TestData {
 
   @Benchmark
-  def decodeToCaseClass: Either[Throwable, Table] =
-    Decoder[Table].apply(result)
+  def decodeToCaseClass: Table[Columns] =
+    Decoder[Table[Columns]].apply(resultForColumns) match {
+      case Right(v) => v
+      case Left(e)  => throw e
+    }
 
   @Benchmark
-  def decodeToMap: Either[Throwable, Map[String, Columns]] =
-    Decoder[Map[String, Columns]].apply(result)
+  def decodeToMap: Map[String, Columns] =
+    Decoder[Map[String, Columns]].apply(resultForColumns) match {
+      case Right(v) => v
+      case Left(e)  => throw e
+    }
+
+  @Benchmark
+  def decodeSelf: Map[String, Columns] =
+    try {
+      val cf = Bytes.toBytes("cf1")
+      val m  = mutable.Map.empty[String, Columns]
+      val r  = resultForColumns
+      val c = Columns(
+        Option(r.getValue(cf, Bytes.toBytes("a"))).map(Bytes.toInt),
+        Option(r.getValue(cf, Bytes.toBytes("b"))).map(Bytes.toFloat),
+        Option(r.getValue(cf, Bytes.toBytes("c"))).map(Bytes.toLong),
+        Option(r.getValue(cf, Bytes.toBytes("d"))).map(Bytes.toDouble),
+        Option(r.getValue(cf, Bytes.toBytes("e"))).map(Bytes.toString),
+        Option(r.getValue(cf, Bytes.toBytes("g"))).map(Bytes.toBoolean),
+        Option(r.getValue(cf, Bytes.toBytes("h"))).map(Bytes.toShort),
+        Option(r.getValue(cf, Bytes.toBytes("i"))).map(Bytes.toBigDecimal(_))
+      )
+      m += "cf1" -> c
+      m.toMap
+    } catch {
+      case NonFatal(e) => throw e
+    }
 }

--- a/modules/benchmark/src/test/scala/orcus/codec/benchmark/TestData.scala
+++ b/modules/benchmark/src/test/scala/orcus/codec/benchmark/TestData.scala
@@ -9,8 +9,8 @@ import org.apache.hadoop.hbase.util.Bytes
 
 import scala.collection.JavaConverters._
 
-final case class Table(
-    cf1: Columns
+final case class Table[A](
+    cf1: A
 )
 
 final case class Columns(a: Option[Int] = None,
@@ -40,5 +40,5 @@ class TestData {
     cell("i", Bytes.toBytes(BigDecimal(10).bigDecimal))
   ).asJava
 
-  val result: Result = Result.create(cells)
+  def resultForColumns: Result = Result.create(cells)
 }


### PR DESCRIPTION
```
[info] Benchmark                        Mode  Cnt    Score    Error   Units
[info] DecoderBench.decodeSelf         thrpt   20  279.065 ±  6.515  ops/ms
[info] DecoderBench.decodeToCaseClass  thrpt   20  289.037 ± 11.075  ops/ms
[info] DecoderBench.decodeToMap        thrpt   20  277.261 ± 15.073  ops/ms
```