### PR TITLE
Remove the unnecessary laziness

### DIFF
--- a/modules/core/src/main/scala/orcus/codec/Decoder.scala
+++ b/modules/core/src/main/scala/orcus/codec/Decoder.scala
@@ -121,14 +121,14 @@ trait Decoder1 extends Decoder2 {
       implicit
       K: Witness.Aux[K],
       H: FamilyDecoder[H],
-      T: Lazy[Decoder[T]]): Decoder[FieldType[K, H] :: T] =
+      T: Decoder[T]): Decoder[FieldType[K, H] :: T] =
     new Decoder[FieldType[K, H] :: T] {
       def apply(result: Result): Either[Throwable, FieldType[K, H] :: T] = {
         val k = Bytes.toBytes(K.value.name)
         val h = orcus.result.getFamily[H, Either[Throwable, ?]](result, k)
         h match {
           case Right(v0) =>
-            T.value(result) match {
+            T(result) match {
               case Right(t) => Right(field[K](v0) :: t)
               case Left(e)  => Left(e)
             }

--- a/modules/core/src/main/scala/orcus/codec/FamilyDecoder.scala
+++ b/modules/core/src/main/scala/orcus/codec/FamilyDecoder.scala
@@ -104,14 +104,14 @@ trait FamilyDecoder2 extends FamilyDecoder3 {
       implicit
       K: Witness.Aux[K],
       H: ValueCodec[H],
-      T: Lazy[FamilyDecoder[T]]): FamilyDecoder[FieldType[K, H] :: T] =
+      T: FamilyDecoder[T]): FamilyDecoder[FieldType[K, H] :: T] =
     new FamilyDecoder[FieldType[K, H] :: T] {
       def apply(map: util.NavigableMap[Array[Byte], Array[Byte]])
         : Either[Throwable, FieldType[K, H] :: T] = {
         try {
           val h  = Option(map.get(Bytes.toBytes(K.value.name))).orEmpty
           val h0 = field[K](H.decode(h).getOrElse(null.asInstanceOf[H]))
-          T.value(map) match {
+          T(map) match {
             case Right(t) => Right(h0 :: t)
             case Left(e)  => Left(e)
           }
@@ -137,13 +137,13 @@ trait FamilyDecoder3 {
 
   implicit def decodeOption[A0](
       implicit
-      A: Lazy[FamilyDecoder[A0]]): FamilyDecoder[Option[A0]] =
+      A: FamilyDecoder[A0]): FamilyDecoder[Option[A0]] =
     new FamilyDecoder[Option[A0]] {
       def apply(map: util.NavigableMap[Array[Byte], Array[Byte]]): Either[Throwable, Option[A0]] =
         if (map == null || map.isEmpty)
           Right(None)
         else
-          A.value(map) match {
+          A(map) match {
             case Right(v) => Right(Some(v))
             case Left(e)  => Left(e)
           }

--- a/modules/core/src/main/scala/orcus/codec/PutEncoder.scala
+++ b/modules/core/src/main/scala/orcus/codec/PutEncoder.scala
@@ -16,12 +16,12 @@ object PutEncoder extends PutEncoder1 {
   implicit def mapPutEncoder[K, V](
       implicit
       K: ValueCodec[K],
-      V: Lazy[PutFamilyEncoder[V]]
+      V: PutFamilyEncoder[V]
   ): PutEncoder[Map[K, V]] = new PutEncoder[Map[K, V]] {
     def apply(acc: Put, a: Map[K, V]): Put = {
       a.foreach {
         case (k, v) =>
-          V.value.apply(acc, K.encode(Option(k)), v)
+          V(acc, K.encode(Option(k)), v)
       }
       acc
     }
@@ -37,13 +37,13 @@ trait PutEncoder1 {
   implicit def labelledHConsPutEncoder[K <: Symbol, H, T <: HList](
       implicit
       K: Witness.Aux[K],
-      H: Lazy[PutFamilyEncoder[H]],
-      T: Lazy[PutEncoder[T]]
+      H: PutFamilyEncoder[H],
+      T: PutEncoder[T]
   ): PutEncoder[FieldType[K, H] :: T] = new PutEncoder[FieldType[K, H] :: T] {
     def apply(acc: Put, a: FieldType[K, H] :: T): Put = a match {
       case h :: t =>
-        val hp = H.value(acc, Bytes.toBytes(K.value.name), h)
-        T.value(hp, t)
+        val hp = H(acc, Bytes.toBytes(K.value.name), h)
+        T(hp, t)
     }
   }
 

--- a/modules/core/src/main/scala/orcus/codec/PutFamilyEncoder.scala
+++ b/modules/core/src/main/scala/orcus/codec/PutFamilyEncoder.scala
@@ -38,12 +38,12 @@ trait PutFamilyEncoder1 {
       implicit
       K: Witness.Aux[K],
       H: ValueCodec[H],
-      T: Lazy[PutFamilyEncoder[T]]
+      T: PutFamilyEncoder[T]
   ): PutFamilyEncoder[FieldType[K, H] :: T] = new PutFamilyEncoder[FieldType[K, H] :: T] {
     def apply(acc: Put, cf: Array[Byte], a: FieldType[K, H] :: T): Put = a match {
       case h :: t =>
         val hp = acc.addColumn(cf, Bytes.toBytes(K.value.name), H.encode(Option(h)))
-        T.value(hp, cf, t)
+        T(hp, cf, t)
     }
   }
 


### PR DESCRIPTION
A case class derivation has become faster.

current master

```
[info] Benchmark                                         (size)   Mode  Cnt    Score   Error   Units
[info] DecoderBench.decodeSelf                               10  thrpt   20  366.514 ± 6.585  ops/ms
[info] DecoderBench.decodeSelf                               30  thrpt   20  102.063 ± 1.192  ops/ms
[info] DecoderBench.decodeToCaseClass                        10  thrpt   20  298.655 ± 7.995  ops/ms
[info] DecoderBench.decodeToCaseClass                        30  thrpt   20   89.264 ± 1.342  ops/ms
[info] DecoderBench.decodeToCaseClassCachedDecoder           10  thrpt   20  355.724 ± 4.713  ops/ms
[info] DecoderBench.decodeToCaseClassCachedDecoder           30  thrpt   20  105.665 ± 1.411  ops/ms
[info] DecoderBench.decodeToMap                              10  thrpt   20  269.529 ± 2.802  ops/ms
[info] DecoderBench.decodeToMap                              30  thrpt   20   88.865 ± 1.237  ops/ms
[info] PutEncoderBench.encodeFromCaseClass                   10  thrpt   20  453.066 ± 10.942  ops/ms
[info] PutEncoderBench.encodeFromCaseClass                   30  thrpt   20  153.302 ±  3.588  ops/ms
[info] PutEncoderBench.encodeFromCaseClassCachedEncoder      10  thrpt   20  658.304 ± 16.896  ops/ms
[info] PutEncoderBench.encodeFromCaseClassCachedEncoder      30  thrpt   20  230.562 ±  6.825  ops/ms
[info] PutEncoderBench.encodeFromMap                         10  thrpt   20  696.779 ± 14.908  ops/ms
[info] PutEncoderBench.encodeFromMap                         30  thrpt   20  238.708 ±  5.202  ops/ms
```

this PR

```
[info] Benchmark                                         (size)   Mode  Cnt    Score    Error   Units
[info] DecoderBench.decodeSelf                               10  thrpt   20  354.381 ± 13.161  ops/ms
[info] DecoderBench.decodeSelf                               30  thrpt   20  103.059 ±  1.842  ops/ms
[info] DecoderBench.decodeToCaseClass                        10  thrpt   20  329.908 ±  4.829  ops/ms
[info] DecoderBench.decodeToCaseClass                        30  thrpt   20  101.625 ±  2.160  ops/ms
[info] DecoderBench.decodeToCaseClassCachedDecoder           10  thrpt   20  352.103 ±  8.697  ops/ms
[info] DecoderBench.decodeToCaseClassCachedDecoder           30  thrpt   20  105.546 ±  2.291  ops/ms
[info] DecoderBench.decodeToMap                              10  thrpt   20  232.200 ± 21.345  ops/ms
[info] DecoderBench.decodeToMap                              30  thrpt   20   82.773 ±  7.637  ops/ms
[info] PutEncoderBench.encodeFromCaseClass                   10  thrpt   20  585.058 ± 11.152  ops/ms
[info] PutEncoderBench.encodeFromCaseClass                   30  thrpt   20  212.122 ±  3.560  ops/ms
[info] PutEncoderBench.encodeFromCaseClassCachedEncoder      10  thrpt   20  671.182 ± 11.830  ops/ms
[info] PutEncoderBench.encodeFromCaseClassCachedEncoder      30  thrpt   20  234.327 ±  5.075  ops/ms
[info] PutEncoderBench.encodeFromMap                         10  thrpt   20  694.034 ± 21.357  ops/ms
[info] PutEncoderBench.encodeFromMap                         30  thrpt   20  241.655 ±  3.476  ops/ms
```
