### PR TITLE
Cleanup code and improve the decoding performance of the Map

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val `cats-effect` = project
   .settings(
     libraryDependencies ++= Seq.concat(
       Seq(
-      Pkg.catsEffect,
+        Pkg.catsEffect,
       ),
       Pkg.forTest,
     ).map(_.withSources),

--- a/modules/benchmark/src/test/scala/orcus/codec/benchmark/DecoderBench.scala
+++ b/modules/benchmark/src/test/scala/orcus/codec/benchmark/DecoderBench.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable
 @Measurement(iterations = 10, time = 1)
 @Threads(1)
 @Fork(2)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
 class DecoderBench {
   import States._
 

--- a/modules/core/src/main/scala/orcus/codec/PutEncoder.scala
+++ b/modules/core/src/main/scala/orcus/codec/PutEncoder.scala
@@ -13,7 +13,7 @@ object PutEncoder extends PutEncoder1 {
 
   def apply[A](implicit A: PutEncoder[A]): PutEncoder[A] = A
 
-  implicit def mapPutEncoder[K, V](
+  implicit def encodeMap[K, V](
       implicit
       K: ValueCodec[K],
       V: PutFamilyEncoder[V]
@@ -21,20 +21,20 @@ object PutEncoder extends PutEncoder1 {
     def apply(acc: Put, a: Map[K, V]): Put = {
       a.foreach {
         case (k, v) =>
-          V(acc, K.encode(Option(k)), v)
+          V(acc, K.encode(k), v)
       }
       acc
     }
   }
 }
 
-trait PutEncoder1 {
+private[codec] trait PutEncoder1 {
 
-  implicit val hnilPutEncoder: PutEncoder[HNil] = new PutEncoder[HNil] {
+  implicit val encodeHNil: PutEncoder[HNil] = new PutEncoder[HNil] {
     def apply(acc: Put, a: HNil): Put = acc
   }
 
-  implicit def labelledHConsPutEncoder[K <: Symbol, H, T <: HList](
+  implicit def encodeLabelledHCons[K <: Symbol, H, T <: HList](
       implicit
       K: Witness.Aux[K],
       H: PutFamilyEncoder[H],
@@ -47,11 +47,9 @@ trait PutEncoder1 {
     }
   }
 
-  implicit def caseClassPutEncoder[A, R](
-      implicit
-      gen: LabelledGeneric.Aux[A, R],
-      R: Lazy[PutEncoder[R]]
-  ): PutEncoder[A] = new PutEncoder[A] {
+  implicit def encodeCaseClass[A, R](implicit
+                                     gen: LabelledGeneric.Aux[A, R],
+                                     R: Lazy[PutEncoder[R]]): PutEncoder[A] = new PutEncoder[A] {
     def apply(acc: Put, a: A): Put = {
       R.value(acc, gen.to(a))
     }

--- a/modules/core/src/main/scala/orcus/codec/ValueCodec.scala
+++ b/modules/core/src/main/scala/orcus/codec/ValueCodec.scala
@@ -1,91 +1,91 @@
 package orcus.codec
 
+import cats.syntax.either._
 import org.apache.hadoop.hbase.util.Bytes
 
 trait ValueCodec[A] { self =>
 
-  def encode(a: Option[A]): Array[Byte]
-  def decode(bytes: Array[Byte]): Option[A]
+  def encode(a: A): Array[Byte]
+  def decode(bytes: Array[Byte]): ValueCodec.Result[A]
 
-  def imap[B](fa: B => A, fb: A => B): ValueCodec[B] = new ValueCodec[B] {
-    def encode(a: Option[B]): Array[Byte]     = self.encode(a.map(fa))
-    def decode(bytes: Array[Byte]): Option[B] = self.decode(bytes).map(fb)
+  final def imap[B](fa: B => A, fb: A => B): ValueCodec[B] = new ValueCodec[B] {
+    def encode(a: B): Array[Byte]                        = self.encode(fa(a))
+    def decode(bytes: Array[Byte]): ValueCodec.Result[B] = self.decode(bytes).map(fb)
   }
 }
 
 object ValueCodec {
 
+  type Result[A] = Either[Throwable, A]
+
   def apply[A](implicit A: ValueCodec[A]): ValueCodec[A] = A
 
   implicit val codecForBytes: ValueCodec[Array[Byte]] = new ValueCodec[Array[Byte]] {
-    def encode(a: Option[Array[Byte]]): Array[Byte]     = a.orEmpty
-    def decode(bytes: Array[Byte]): Option[Array[Byte]] = Option(bytes)
+    def encode(a: Array[Byte]): Array[Byte]             = a
+    def decode(bytes: Array[Byte]): Result[Array[Byte]] = Right(bytes)
   }
 
   implicit val codecForBoolean: ValueCodec[Boolean] = new ValueCodec[Boolean] {
-    def encode(a: Option[Boolean]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Boolean] =
-      if (bytes.isEmpty) None else Some(Bytes.toBoolean(bytes))
+    def encode(a: Boolean): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Boolean] =
+      Either.catchNonFatal(Bytes.toBoolean(bytes))
   }
 
   implicit val codecForShort: ValueCodec[Short] = new ValueCodec[Short] {
-    def encode(a: Option[Short]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Short] =
-      if (bytes.isEmpty) None else Some(Bytes.toShort(bytes))
+    def encode(a: Short): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Short] =
+      Either.catchNonFatal(Bytes.toShort(bytes))
   }
 
   implicit val codecForInt: ValueCodec[Int] = new ValueCodec[Int] {
-    def encode(a: Option[Int]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Int] =
-      if (bytes.isEmpty) None else Some(Bytes.toInt(bytes))
+    def encode(a: Int): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Int] =
+      Either.catchNonFatal(Bytes.toInt(bytes))
   }
 
   implicit val codecForLong: ValueCodec[Long] = new ValueCodec[Long] {
-    def encode(a: Option[Long]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Long] =
-      if (bytes.isEmpty) None else Some(Bytes.toLong(bytes))
+    def encode(a: Long): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Long] =
+      Either.catchNonFatal(Bytes.toLong(bytes))
   }
 
   implicit val codecForFloat: ValueCodec[Float] = new ValueCodec[Float] {
-    def encode(a: Option[Float]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Float] =
-      if (bytes.isEmpty) None else Some(Bytes.toFloat(bytes))
+    def encode(a: Float): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Float] =
+      Either.catchNonFatal(Bytes.toFloat(bytes))
   }
 
   implicit val codecForDouble: ValueCodec[Double] = new ValueCodec[Double] {
-    def encode(a: Option[Double]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[Double] =
-      if (bytes.isEmpty) None else Some(Bytes.toDouble(bytes))
+    def encode(a: Double): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[Double] =
+      Either.catchNonFatal(Bytes.toDouble(bytes))
   }
 
   implicit val codecForBigInt: ValueCodec[BigDecimal] = new ValueCodec[BigDecimal] {
-    def encode(a: Option[BigDecimal]): Array[Byte] =
-      a.map(v => Bytes.toBytes(v.bigDecimal)).orEmpty
-    def decode(bytes: Array[Byte]): Option[BigDecimal] =
-      if (bytes.isEmpty) None else Some(BigDecimal(Bytes.toBigDecimal(bytes)))
+    def encode(a: BigDecimal): Array[Byte] = Bytes.toBytes(a.bigDecimal)
+    def decode(bytes: Array[Byte]): Result[BigDecimal] =
+      Either.catchNonFatal(BigDecimal(Bytes.toBigDecimal(bytes)))
   }
 
   implicit val codecForString: ValueCodec[String] = new ValueCodec[String] {
-    def encode(a: Option[String]): Array[Byte] =
-      a.map(Bytes.toBytes).orEmpty
-    def decode(bytes: Array[Byte]): Option[String] =
-      if (bytes == null) None else Option(Bytes.toString(bytes))
+    def encode(a: String): Array[Byte] = Bytes.toBytes(a)
+    def decode(bytes: Array[Byte]): Result[String] =
+      Either.catchNonFatal(Bytes.toString(bytes))
   }
+
+  implicit val codecForOptionString: ValueCodec[Option[String]] =
+    new ValueCodec[Option[String]] {
+      private[this] val c = ValueCodec[String]
+      def encode(a: Option[String]): Array[Byte] =
+        a.fold(Array.emptyByteArray)(c.encode)
+      def decode(bytes: Array[Byte]): Result[Option[String]] =
+        if (bytes == null) Right(None) else c.decode(bytes).map(Option.apply)
+    }
 
   implicit def codecForOption[A](implicit A: ValueCodec[A]): ValueCodec[Option[A]] =
     new ValueCodec[Option[A]] {
-      def encode(a: Option[Option[A]]): Array[Byte] =
-        a match {
-          case Some(v) => A.encode(v)
-          case _       => Array.emptyByteArray
-        }
-      def decode(bytes: Array[Byte]): Option[Option[A]] =
-        if (bytes.isEmpty) Some(None) else Option(A.decode(bytes))
+      def encode(a: Option[A]): Array[Byte] = a.fold(Array.emptyByteArray)(A.encode)
+      def decode(bytes: Array[Byte]): Result[Option[A]] =
+        if (bytes == null || bytes.isEmpty) Right(None) else A.decode(bytes).map(Option.apply)
     }
 }

--- a/modules/core/src/main/scala/orcus/codec/package.scala
+++ b/modules/core/src/main/scala/orcus/codec/package.scala
@@ -1,8 +1,0 @@
-package orcus
-
-package object codec {
-
-  implicit class ArrayOps private[orcus] (val a: Option[Array[Byte]]) extends AnyVal {
-    def orEmpty: Array[Byte] = a.getOrElse(Array.emptyByteArray)
-  }
-}

--- a/modules/core/src/test/scala/orcus/codec/FamilyDecoderSpec.scala
+++ b/modules/core/src/test/scala/orcus/codec/FamilyDecoderSpec.scala
@@ -59,41 +59,18 @@ class FamilyDecoderSpec extends FunSuite with Matchers {
     m.put(Bytes.toBytes("a"), null)
     m.put(Bytes.toBytes("b"), Array.emptyByteArray)
     m.put(Bytes.toBytes("c"), Bytes.toBytes("d"))
-    assert(f(m) === Right(Map("a" -> "", "b" -> "", "c" -> "d")))
+    assert(f(m) === Right(Map("b" -> "", "c" -> "d")))
   }
 
   test("It should avoid a null values when its column value is null/empty") {
     val f = FamilyDecoder[Map[String, Boolean]]
-    val m = new ju.TreeMap[Array[Byte], Array[Byte]](Bytes.BYTES_COMPARATOR)
-    m.put(Bytes.toBytes("a"), null)
-    m.put(Bytes.toBytes("b"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("c"), Bytes.toBytes(true))
-    m.put(Bytes.toBytes("d"), Bytes.toBytes(false))
+    val m = new ju.TreeMap[Array[Byte], Array[Byte]](Bytes.BYTES_COMPARATOR) {
+      put(Bytes.toBytes("a"), null)
+      put(Bytes.toBytes("b"), Array.emptyByteArray)
+      put(Bytes.toBytes("c"), Bytes.toBytes(true))
+      put(Bytes.toBytes("d"), Bytes.toBytes(false))
+    }
     assert(f(m) === Right(Map("c" -> true, "d" -> false)))
-  }
-
-  test("It should return map with empty values when column value is empty") {
-    case class All(a: Option[Int] = None,
-                   b: Option[Float] = None,
-                   c: Option[Long] = None,
-                   d: Option[Double] = None,
-                   e: Option[String] = None,
-                   f: Option[Array[Byte]] = None,
-                   g: Option[Boolean] = None,
-                   h: Option[Short] = None,
-                   i: Option[BigDecimal] = None)
-    val f = FamilyDecoder[All]
-    val m = new ju.TreeMap[Array[Byte], Array[Byte]](Bytes.BYTES_COMPARATOR)
-    m.put(Bytes.toBytes("a"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("b"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("c"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("d"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("e"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("f"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("g"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("h"), Array.emptyByteArray)
-    m.put(Bytes.toBytes("i"), Array.emptyByteArray)
-    assert(f(m) === Right(All()))
   }
 
   test("pure") {


### PR DESCRIPTION
current master

```
[info] Benchmark                                    (size)   Mode  Cnt       Score      Error  Units
[info] DecoderBench.decodeSelf                          10  thrpt   20  361210.915 ± 6105.123  ops/s
[info] DecoderBench.decodeSelf                          30  thrpt   20  103226.093 ± 1403.922  ops/s
[info] DecoderBench.decodeToCaseClass                   10  thrpt   20  328102.225 ± 6773.216  ops/s
[info] DecoderBench.decodeToCaseClass                   30  thrpt   20  101035.228 ± 1049.479  ops/s
[info] DecoderBench.decodeToCaseClassCachedDecoder      10  thrpt   20  353435.104 ± 6272.487  ops/s
[info] DecoderBench.decodeToCaseClassCachedDecoder      30  thrpt   20  105248.537 ± 1794.158  ops/s
[info] DecoderBench.decodeToMap                         10  thrpt   20  257109.247 ± 9525.354  ops/s
[info] DecoderBench.decodeToMap                         30  thrpt   20   87897.808 ± 1161.379  ops/s
```

this PR

```
[info] Benchmark                                    (size)   Mode  Cnt       Score       Error  Units
[info] DecoderBench.decodeSelf                          10  thrpt   20  362397.142 ±  7316.538  ops/s
[info] DecoderBench.decodeSelf                          30  thrpt   20  104472.350 ±  1569.480  ops/s
[info] DecoderBench.decodeToCaseClass                   10  thrpt   20  323035.057 ±  5057.819  ops/s
[info] DecoderBench.decodeToCaseClass                   30  thrpt   20  100794.912 ±  1896.704  ops/s
[info] DecoderBench.decodeToCaseClassCachedDecoder      10  thrpt   20  350700.835 ± 11481.967  ops/s
[info] DecoderBench.decodeToCaseClassCachedDecoder      30  thrpt   20  105769.920 ±  1213.758  ops/s
[info] DecoderBench.decodeToMap                         10  thrpt   20  278057.669 ±  5989.611  ops/s
[info] DecoderBench.decodeToMap                         30  thrpt   20   88068.112 ±  1948.720  ops/s
```

