### PR TITLE
Add Arrows/ Twitter / Task module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / crossScalaVersions := Seq(
   Ver.`scala2.11`,
   Ver.`scala2.12`
 )
-ThisBuild / libraryDependencies ++= Seq(
+ThisBuild / libraryDependencies ++= Pkg.forTest ++ Seq(
   compilerPlugin(Pkg.kindProjector),
   compilerPlugin(Pkg.macroParadise cross CrossVersion.patch)
 )
@@ -55,8 +55,8 @@ lazy val orcus = project.in(file("."))
     Compile / console / scalacOptions --= warnCompilerOptions,
     Compile / console / scalacOptions += "-Yrepl-class-based"
   )
-  .aggregate(core, monix, `twitter-util`, `cats-effect`, free, iota, example, benchmark)
-  .dependsOn(core, monix, `twitter-util`, `cats-effect`, free, iota, example, benchmark)
+  .aggregate(core, `arrows-twitter`, `twitter-util`, monix, `cats-effect`, free, iota, example, benchmark)
+  .dependsOn(core, `arrows-twitter`, `twitter-util`, monix, `cats-effect`, free, iota, example, benchmark)
 
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,
@@ -112,7 +112,6 @@ lazy val core = project
         Pkg.scalaReflect(scalaVersion.value),
         Pkg.hbase % "provided"
       ),
-      Pkg.forTest,
     ).map(_.withSources),
   )
 
@@ -124,11 +123,8 @@ lazy val monix = project
     moduleName := "orcus-monix",
   )
   .settings(
-    libraryDependencies ++= Seq.concat(
-      Seq(
-        Pkg.monixEval,
-      ),
-      Pkg.forTest,
+    libraryDependencies ++= Seq(
+      Pkg.monixEval,
     ).map(_.withSources),
   )
   .dependsOn(core)
@@ -141,11 +137,22 @@ lazy val `twitter-util` = project
     moduleName := "orcus-twitter-util",
   )
   .settings(
-    libraryDependencies ++= Seq.concat(
-      Seq(
-        Pkg.twitterUtil,
-      ),
-      Pkg.forTest,
+    libraryDependencies ++= Seq(
+      Pkg.twitterUtil,
+    ).map(_.withSources),
+  )
+  .dependsOn(core)
+
+lazy val `arrows-twitter` = project
+  .in(file("modules/arrows-twitter"))
+  .settings(publishSettings)
+  .settings(
+    description := "orcus arrows-twitter",
+    moduleName := "orcus-arrows-twitter",
+  )
+  .settings(
+    libraryDependencies ++= Seq(
+      Pkg.twitterArrows,
     ).map(_.withSources),
   )
   .dependsOn(core)
@@ -158,11 +165,8 @@ lazy val `cats-effect` = project
     moduleName := "orcus-cats-effect",
   )
   .settings(
-    libraryDependencies ++= Seq.concat(
-      Seq(
-        Pkg.catsEffect,
-      ),
-      Pkg.forTest,
+    libraryDependencies ++= Seq(
+      Pkg.catsEffect,
     ).map(_.withSources),
   )
   .dependsOn(core)
@@ -175,12 +179,9 @@ lazy val free = project
     moduleName := "orcus-free",
   )
   .settings(
-    libraryDependencies ++= Seq.concat(
-      Seq(
+    libraryDependencies ++= Seq(
         Pkg.catsFree,
         Pkg.hbase % "provided"
-      ),
-      Pkg.forTest,
     ).map(_.withSources),
   )
   .dependsOn(core)
@@ -193,12 +194,9 @@ lazy val iota = project
     moduleName := "orcus-iota",
   )
   .settings(
-    libraryDependencies ++= Seq.concat(
-      Seq(
-        Pkg.iota,
-        Pkg.hbase % "provided",
-      ),
-      Pkg.forTest,
+    libraryDependencies ++= Seq(
+      Pkg.iota,
+      Pkg.hbase % "provided",
     ).map(_.withSources),
   )
   .dependsOn(free)
@@ -239,6 +237,7 @@ lazy val benchmark = (project in file("modules/benchmark"))
   .dependsOn(Seq(
     iota,
     `twitter-util`,
+    `arrows-twitter`,
     `cats-effect`,
     monix,
   ).map(_ % "test->test"): _*)

--- a/modules/arrows-twitter/src/main/scala/orcus/async/arrowstwitter/ArrowsTwitterAsyncHandlerInstances.scala
+++ b/modules/arrows-twitter/src/main/scala/orcus/async/arrowstwitter/ArrowsTwitterAsyncHandlerInstances.scala
@@ -1,0 +1,36 @@
+package orcus.async.arrowstwitter
+
+import arrows.twitter.Task
+import com.twitter.util.{FuturePool, Promise}
+import orcus.async.{AsyncHandler, Callback}
+
+trait ArrowsTwitterAsyncHandlerInstances {
+
+  implicit val arrowsTwitterTaskAsyncHandler: AsyncHandler[Task] =
+    new AsyncHandler[Task] {
+      def handle[A](callback: Callback[A], cancel: => Unit): Task[A] = {
+        Task.async {
+          val p = Promise[A]
+          callback {
+            case Left(e)  => p.setException(e)
+            case Right(v) => p.setValue(v)
+          }
+          p
+        }
+      }
+    }
+
+  def arrowsTwitterForkedTaskAsyncHandler(implicit fp: FuturePool): AsyncHandler[Task] =
+    new AsyncHandler[Task] {
+      def handle[A](callback: Callback[A], cancel: => Unit): Task[A] = {
+        Task.fork(fp)(Task.async {
+          val p = Promise[A]
+          callback {
+            case Left(e)  => p.setException(e)
+            case Right(v) => p.setValue(v)
+          }
+          p
+        })
+      }
+    }
+}

--- a/modules/arrows-twitter/src/main/scala/orcus/async/arrowstwitter/package.scala
+++ b/modules/arrows-twitter/src/main/scala/orcus/async/arrowstwitter/package.scala
@@ -1,0 +1,3 @@
+package orcus.async
+
+package object arrowstwitter extends ArrowsTwitterAsyncHandlerInstances

--- a/modules/arrows-twitter/src/test/scala/orcus/async/arrowstwitter/ArrowsTwitterAsyncHandlerSpec.scala
+++ b/modules/arrows-twitter/src/test/scala/orcus/async/arrowstwitter/ArrowsTwitterAsyncHandlerSpec.scala
@@ -1,0 +1,30 @@
+package orcus.async.arrowstwitter
+
+import java.util.concurrent.{CompletableFuture, CompletionException}
+import java.util.function.Supplier
+
+import arrows.twitter.Task
+import cats.~>
+import com.twitter.util.Await
+import orcus.async._
+import org.scalatest.FunSpec
+
+class ArrowsTwitterAsyncHandlerSpec extends FunSpec {
+
+  describe("AsyncHandler[Task]") {
+    it("should get a value as-is when its CompletableFuture is succeed") {
+      def run(implicit f: CompletableFuture ~> Task) =
+        f(CompletableFuture.completedFuture(10)).run
+
+      assert(10 === Await.result(run))
+    }
+    it("should throw CompletionException as-is when its CompletableFuture is fail") {
+      def run(implicit f: CompletableFuture ~> Task) =
+        f(CompletableFuture.supplyAsync(new Supplier[Int] {
+          def get(): Int = throw new Exception
+        })).run
+
+      assertThrows[CompletionException](Await.result(run))
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
     val scalafmt         = "1.3.0"
     val cats             = "1.1.0"
     val monix            = "3.0.0-RC1"
+    val twitterArrows    = "0.1.21"
     val twitterUtil      = "18.7.0"
     val catsEffect       = "1.0.0-RC2"
     val iota             = "0.3.8"
@@ -28,6 +29,7 @@ object Dependencies {
     lazy val catsFree       = "org.typelevel"             %% "cats-free"          % Ver.cats
     lazy val catsEffect     = "org.typelevel"             %% "cats-effect"        % Ver.catsEffect
     lazy val monixEval      = "io.monix"                  %% "monix-eval"         % Ver.monix
+    lazy val twitterArrows  = "io.trane"                  %% "arrows-twitter"     % Ver.twitterArrows
     lazy val twitterUtil    = "com.twitter"               %% "util-core"          % Ver.twitterUtil
     lazy val catbirdUtil    = "io.catbird"                %% "catbird-util"       % Ver.twitterUtil
     lazy val iota           = "io.frees"                  %% "iota-core"          % Ver.iota


### PR DESCRIPTION


```
> benchmark/jmh:run -p threads=16 -t 4 .*(ArrowsTwitterAsyncHandler|TwitterAsyncHandler|ScalaJavaConverter).bench

[info] Benchmark                        (threads)   Mode  Cnt      Score      Error  Units
[info] ArrowsTwitterAsyncHandler.bench         16  thrpt   20  47991.766 ± 4631.997  ops/s
[info] ScalaJavaConverter.bench                16  thrpt   20  24728.907 ±  628.636  ops/s
[info] TwitterAsyncHandler.bench               16  thrpt   20  33347.236 ± 1750.539  ops/s
```