### PR TITLE
feat: change emtpy ByteStrig decoding to None

### DIFF
--- a/modules/bigtable/src/main/scala/orcus/bigtable/codec/PrimitiveDecoder.scala
+++ b/modules/bigtable/src/main/scala/orcus/bigtable/codec/PrimitiveDecoder.scala
@@ -72,7 +72,7 @@ private[bigtable] trait PrimitiveDecoder1 {
 
   implicit def decodeOptionA[A](implicit A: PrimitiveDecoder[A]): PrimitiveDecoder[Option[A]] =
     bs =>
-      try if (bs == null) Right(None) else A.apply(bs).map(Option.apply)
+      try if (bs == null || bs.isEmpty()) Right(None) else A.apply(bs).map(Option.apply)
       catch {
         case NonFatal(e) => Left(e)
       }

--- a/modules/bigtable/src/test/scala/orcus/bigtable/codec/RowDecoderTest.scala
+++ b/modules/bigtable/src/test/scala/orcus/bigtable/codec/RowDecoderTest.scala
@@ -8,7 +8,7 @@ import org.apache.hadoop.hbase.util.Bytes
 import org.scalatest.funsuite.AnyFunSuite
 
 class RowDecoderTest extends AnyFunSuite {
-  case class Foo(c1: Bar, c2: Option[Baz])
+  case class Foo(c1: Bar, c2: Option[Baz], c3: Option[Baz] = None)
 
   object Foo {
     implicit val decode: RowDecoder[Foo] = derivedRowDecoder[Foo]
@@ -18,7 +18,7 @@ class RowDecoderTest extends AnyFunSuite {
   object Bar {
     implicit val decode: FamilyDecoder[Bar] = derivedFamilyDecoder[Bar]
   }
-  case class Baz(d: Long, e: Boolean, f: Float)
+  case class Baz(d: Long, e: Boolean, f: Float, g: Option[Int] = None, h: Option[Long] = None)
 
   object Baz {
     implicit val decode: FamilyDecoder[Baz] = derivedFamilyDecoder[Baz]
@@ -106,11 +106,41 @@ class RowDecoderTest extends AnyFunSuite {
             java.util.List.of(),
             ByteString.copyFrom(Bytes.toBytes("string"))
           )
+        ),
+        "c3" -> List(
+          RowCell.create(
+            "c3",
+            ByteString.copyFromUtf8("d"),
+            ts,
+            java.util.List.of(),
+            ByteString.copyFrom(Bytes.toBytes(101L))
+          ),
+          RowCell.create(
+            "c3",
+            ByteString.copyFromUtf8("e"),
+            ts,
+            java.util.List.of(),
+            ByteString.copyFrom(Bytes.toBytes(true))
+          ),
+          RowCell.create(
+            "c3",
+            ByteString.copyFromUtf8("f"),
+            ts,
+            java.util.List.of(),
+            ByteString.copyFrom(Bytes.toBytes(10.555f))
+          ),
+          RowCell.create(
+            "c3",
+            ByteString.copyFromUtf8("h"),
+            ts,
+            java.util.List.of(),
+            ByteString.EMPTY
+          )
         )
       )
     )
 
-    val expected = Foo(Bar(10, "string", None), None)
+    val expected = Foo(Bar(10, "string", None), None, Some(Baz(101L, true, 10.555f, None, None)))
 
     assert(RowDecoder[Foo].apply(row) === Right(expected))
   }


### PR DESCRIPTION
An empty ByteString always decoded to None on `PrimitiveDecoder[Option[A]]`,  I thought it would be easier to use. 